### PR TITLE
update check period for SSM and InstanceOK

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3040,10 +3040,13 @@ function updateLambdas(userId, cb) {
 				if (folderName.substring(0, 9) == "cloudrig-") {
 					//reporter.report(`Updating ${ folderName } `)
 
-					var timeout = 60;
+					var timeout = 120;
 					if (folderName == "cloudrig-waitForInstanceOk") {
-						timeout = 150;
-					}
+						timeout = 900;
+					} 
+					else if (folderName == "cloudrig-checkMessageSuccess") {
+						timeout = 300;
+					} 
 
 					async.series(
 						[

--- a/lib/lambdas/cloudrig-checkMessageSuccess/index.js
+++ b/lib/lambdas/cloudrig-checkMessageSuccess/index.js
@@ -9,6 +9,7 @@ exports.handler = (event, context, callback) => {
 	var lambdaARNQueue = eventBody.lambdaARNQueue;
 	var common = new commonlib(eventBody);
 
+
 	function run() {
 		var ssm = new AWS.SSM();
 
@@ -33,17 +34,7 @@ exports.handler = (event, context, callback) => {
 					common.report("Command completed successfully");
 					common.triggerNextLambda(lambdaARNQueue, eventBody);
 				} else {
-					var checkMessageSuccess = {
-						arn:
-							"arn:aws:sns:" +
-							eventBody.config.AWSRegion +
-							":" +
-							eventBody.settings.UserID +
-							":cloudrig-checkMessageSuccess",
-						args: eventBody.args
-					};
-					lambdaARNQueue.unshift(checkMessageSuccess);
-					common.scheduleNextLambda("1 minute", lambdaARNQueue, eventBody);
+					setTimeout(run, 2000);
 				}
 			}
 		);

--- a/lib/lambdas/cloudrig-waitForInstanceOk/index.js
+++ b/lib/lambdas/cloudrig-waitForInstanceOk/index.js
@@ -9,27 +9,37 @@ exports.handler = (event, context, callback) => {
 	var lambdaARNQueue = eventBody.lambdaARNQueue;
 	var common = new commonlib(eventBody);
 
-	function run() {
-		common.report("Waiting for our instance to be ready");
-
-		ec2.waitFor(
-			/* Assuming instanceOk doesn't take long to happen,
-            * otherwise this needs to be changed to a cloudwatch rule,
-            * lambda function will timeout if takes too long.
-            */
-			"instanceStatusOk",
+	function check() {
+		ec2.describeInstanceStatus(
 			{
 				InstanceIds: [eventBody.state.instance.InstanceId]
 			},
-			function(err, data) {
+			function (err, data) {
 				if (err) {
 					common.triggerRollback(err);
 					return;
 				}
-				common.report("Instance ready");
-				common.triggerNextLambda(lambdaARNQueue, eventBody);
+
+				if (
+					data.InstanceStatuses.length > 0 &&
+					data.InstanceStatuses[0].InstanceStatus.Status == "ok"
+				) {
+					common.report("Instance ready");
+					common.triggerNextLambda(lambdaARNQueue, eventBody);
+				}
+				else {
+					setTimeout(check, 15000);
+				}
+
 			}
 		);
+	}
+
+
+	function run() {
+		common.report("Waiting for our instance to be ready");
+
+		check();
 	}
 
 	common.start(run, eventBody);

--- a/lib/lambdas/cloudrig-waitSSM/index.js
+++ b/lib/lambdas/cloudrig-waitSSM/index.js
@@ -10,15 +10,9 @@ exports.handler = (event, context, callback) => {
 	var lambdaARNQueue = eventBody.lambdaARNQueue;
 	var common = new commonlib(eventBody);
 
-	function run() {
-		common.report("Waiting for SSM");
+	function check() {
 
 		var ssm = new AWS.SSM();
-
-		var waitForSSM = {
-			arn: "arn:aws:sns:" + eventBody.config.AWSRegion + ":" + eventBody.settings.UserID + ":cloudrig-waitSSM",
-			args: ""
-		};
 
 		ssm.describeInstanceInformation(
 			{
@@ -38,12 +32,18 @@ exports.handler = (event, context, callback) => {
 				if (data.InstanceInformationList.length > 0) {
 					common.triggerNextLambda(lambdaARNQueue, eventBody);
 				} else {
-					// repeat this lambda in one minute
-					lambdaARNQueue.unshift(waitForSSM);
-					common.scheduleNextLambda("1 minute", lambdaARNQueue, eventBody);
+					setTimeout(check, 2000);
 				}
 			}
 		);
+	}
+
+
+	function run() {
+		common.report("Waiting for SSM");
+
+		check();
+
 	}
 
 	common.start(run, eventBody);


### PR DESCRIPTION
SSM and InstanceOK should now check with a better granularity instead of using the cloudwatch rule minimum one minute.