### PR TITLE
Add us-east-2 as an available region

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,7 @@ var zonesArr = {
 	"eu-central-1": ["a", "b"],
 	"eu-west-1": ["a", "b", "c"],
 	"us-east-1": ["a", "b", "c", "d", "e"],
+	"us-east-2": ["a", "b", "c"],
 	"us-west-1": ["a", "b", "c"],
 	"us-west-2": ["a", "b", "c"],
 	"ap-southeast-1": ["a", "b", "c"],


### PR DESCRIPTION
Hello! First of all, your project is awesome.  Thank you for all your hard work! 

I noticed us-east-2 doesn't exist so I added it, unfortunately there's not spot availability at the moment in us-east-* for g3s but oh well.  

Let me know if I missed anything with this, I'll try more testing once the region has more availability.  Thanks!