### PR TITLE
Add 50 GB disk option

### DIFF
--- a/gui/react/src/components/play/Storage.js
+++ b/gui/react/src/components/play/Storage.js
@@ -86,6 +86,7 @@ class Storage extends Component {
 							<Grid.Row>
 								<Grid.Column>
 									<Form.Select label='Create Volume With Size' value={this.state.newVolume} onChange={this.handleChange.bind(this)} options={ [
+										{ key: '50', text: '50 GB', value: 50 },
 										{ key: '100', text: '100 GB', value: 100 },
 										{ key: '150', text: '150 GB', value: 150 },
 										{ key: '200', text: '200 GB', value: 200 },

--- a/lib/ps1/Resize-Drive.ps1
+++ b/lib/ps1/Resize-Drive.ps1
@@ -1,5 +1,5 @@
-$disks = Get-Disk | Where-Object { $_.Size -ge "100GB" }
-foreach ($disk in $disks) { Update-Disk -Number $disk.Number } 
+$disks = Get-Disk | Where-Object { $_.Size -ge "50GB" }
+foreach ($disk in $disks) { Update-Disk -Number $disk.Number }
 $part_size = Get-PartitionSupportedSize -DriveLetter D
 $current_part = Get-Partition -DriveLetter D
 if($part_size.SizeMax -gt $current_part.Size){Resize-Partition -DriveLetter D -Size $part_size.SizeMax}

--- a/lib/ps1/Set-Drive.ps1
+++ b/lib/ps1/Set-Drive.ps1
@@ -1,5 +1,5 @@
 Get-Disk |
-Where-Object { $_.Size -ge "100GB" } |
+Where-Object { $_.Size -ge "50GB" } |
 Initialize-Disk -PartitionStyle MBR -PassThru |
 New-Partition -AssignDriveLetter -DriveLetter D -UseMaximumSize |
 Format-Volume -FileSystem NTFS -NewFileSystemLabel "Games" -Confirm:$false


### PR DESCRIPTION
A quick hack for https://github.com/williamparry/cloudRIG/issues/99. Since the root disk is 30GB, I assume 30 is the lowest we can go without modifying more PS1 code (so I rounded up to 50 for now).

Let me know if there are any issues! Thanks!