### PR TITLE
Add eu-west-2 region

### DIFF
--- a/gui/electron/common.js
+++ b/gui/electron/common.js
@@ -117,11 +117,13 @@ function cmdHandler(event, op, data) {
 
 		case "getZones":
 			event.returnValue = cloudrig.getZonesArr();
-
 			break;
 
 		case "getInstanceTypes":
 			event.returnValue = cloudrig.getInstanceTypesArr();
+
+		case "getInstanceTypesPerRegion":
+			event.returnValue = cloudrig.getInstanceTypesPerRegion();
 
 		case "getConfiguration":
 			event.returnValue = cloudrig.getConfigFile();

--- a/gui/react/src/components/App.js
+++ b/gui/react/src/components/App.js
@@ -343,7 +343,7 @@ class App extends Component {
 								borderRadius: 0,
 								position: "absolute",
 								bottom: "120px",
-								zIndex: 2,
+								zIndex: 1,
 								margin: "0",
 								width: "100%"
 							}}>

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ var standardFilter = [
 var zonesArr = {
 	"eu-central-1": ["a", "b"],
 	"eu-west-1": ["a", "b", "c"],
+	"eu-west-2": ["a", "b", "c"],
 	"us-east-1": ["a", "b", "c", "d", "e"],
 	"us-west-1": ["a", "b", "c"],
 	"us-west-2": ["a", "b", "c"],
@@ -49,6 +50,13 @@ var zonesArr = {
 	"ap-southeast-2": ["a", "b"],
 	"sa-east-1": ["a", "b"]
 };
+
+var instanceTypes = ["g2.2xlarge", "g3s.xlarge", "g3.4xlarge"];
+var instanceTypesFiltering = {
+	"eu-west-2": {
+		"g2.2xlarge": false
+	}
+}
 
 function lambdaFunction() {
 	return `var AWS = require('aws-sdk');
@@ -1956,7 +1964,28 @@ function getRegionAZs(region) {
 }
 
 function getInstanceTypesArr() {
-	return ["g2.2xlarge", "g3s.xlarge", "g3.4xlarge"];
+	return instanceTypes;
+}
+
+function getInstanceTypesForRegion(region) {
+	let availableInstanceTypesForThisRegion = getInstanceTypesArr();
+	// Filter out the instance types that are not available in the selected region
+	if (instanceTypesFiltering[region]) {
+		return availableInstanceTypesForThisRegion.filter(function(instanceType) {
+			// Only filter out an item if it has been explicitely disabled
+			return instanceTypesFiltering[region][instanceType] !== false;
+		}) 
+	} else {
+		return availableInstanceTypesForThisRegion;
+	}
+}
+
+function getInstanceTypesPerRegion() {
+	const instanceTypesPerRegion = {};
+	getRegions().forEach(function(region) {
+		instanceTypesPerRegion[region] = getInstanceTypesForRegion(region);
+	});
+	return instanceTypesPerRegion;
 }
 
 function getRequiredConfig() {
@@ -2020,7 +2049,8 @@ function getRequiredConfig() {
 			key: "AWSInstanceType",
 			title: "AWS Instace Type",
 			help: "Choose how powerful your computer is",
-			options: getInstanceTypesArr()
+			options: getInstanceTypesForRegion,
+			optionsDependsOnPreviousValues: ["AWSRegion"]
 		},
 		{
 			key: "ParsecServerId",
@@ -3260,6 +3290,8 @@ module.exports = {
 	getZonesArr: getZonesArr,
 
 	getInstanceTypesArr: getInstanceTypesArr,
+	
+	getInstanceTypesPerRegion: getInstanceTypesPerRegion,
 
 	getRegions: getRegions,
 


### PR DESCRIPTION
This PR adds the eu-west-2 (London) region. 

As this region does not support g2 instances I've also added the code to filter the instance type list depending on the region.

BTW I've also decreased the zIndex of the update message, as it was on top of the instance type dropdown. 
